### PR TITLE
Remove reference to `demo.png`

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,6 @@ id
 (1 row)
 ```
 
-![demo.png](demo.png)
-
 ## Usage
 
 After installing the extension, you can enable it in your PostgreSQL database with the following command:


### PR DESCRIPTION
There is a link to demo.png, but the file doesn't exist. Dropping the reference.