### PR TITLE
Add DDL guards: CREATE INDEX without CONCURRENTLY, ADD COLUMN DEFAULT on large tables

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 MODULES = pg_savior
 EXTENSION = pg_savior
 DATA = pg_savior--0.0.1.sql
-REGRESS = basic delete_block update_block bypass disabled max_rows
+REGRESS = basic delete_block update_block bypass disabled max_rows unsafe_create_index unsafe_add_column
 
 PG_CONFIG = pg_config
 PGXS := $(shell $(PG_CONFIG) --pgxs)

--- a/README.md
+++ b/README.md
@@ -11,9 +11,11 @@ Under active development. Pre-1.0. Not production-ready.
 - [x] Block `DELETE` without `WHERE`
 - [x] Block `UPDATE` without `WHERE`
 - [x] Row-count threshold guard (`pg_savior.max_rows_affected`)
+- [x] Block `CREATE INDEX` without `CONCURRENTLY`
+- [x] Block `ALTER TABLE ADD COLUMN ... DEFAULT` on large tables
 - [x] Per-session bypass GUC (`pg_savior.bypass`)
 - [x] Global on/off GUC (`pg_savior.enabled`)
-- [ ] Block destructive DDL (`DROP TABLE`, `TRUNCATE`, `DROP DATABASE`, `CREATE INDEX` without `CONCURRENTLY`)
+- [ ] Block other destructive DDL (`DROP TABLE`, `TRUNCATE`, `DROP DATABASE`)
 - [ ] Per-table opt-out via reloptions
 
 ## Installation
@@ -94,6 +96,7 @@ DELETE 1
 | `pg_savior.enabled` | `on` | session (`USERSET`) | Master switch. When `off`, no checks run. |
 | `pg_savior.bypass` | `off` | session (`USERSET`) | When `on`, the current session's `DELETE`/`UPDATE` are allowed through unconditionally. Use to do an intentional bulk operation. |
 | `pg_savior.max_rows_affected` | `0` (disabled) | session (`USERSET`) | When > 0, refuse `DELETE`/`UPDATE` whose planner row estimate exceeds this. Catches destructive queries that *do* have a `WHERE` but match too much (e.g. `DELETE FROM emp WHERE id > 0`). |
+| `pg_savior.large_table_threshold_rows` | `1000000` | session (`USERSET`) | Tables with `pg_class.reltuples` greater than this are considered "large" for the DDL guards (currently: `ALTER TABLE ADD COLUMN ... DEFAULT`). Raise it for permissive environments, lower it for stricter ones. |
 
 Example bypass for an intentional cleanup:
 
@@ -115,6 +118,20 @@ HINT:  Refine the WHERE clause, raise pg_savior.max_rows_affected, or set pg_sav
 ```
 
 The threshold uses the planner's row estimate, which depends on table statistics. For accurate enforcement on a recently-modified table, run `ANALYZE` first.
+
+Example DDL guards:
+
+```
+postgres=# CREATE INDEX emp_idx ON emp (id);
+ERROR:  pg_savior: CREATE INDEX without CONCURRENTLY is blocked
+HINT:  Use CREATE INDEX CONCURRENTLY (it cannot run in a transaction block), or set pg_savior.bypass = on for this session.
+
+postgres=# ALTER TABLE big_emp ADD COLUMN status text DEFAULT 'active';
+ERROR:  pg_savior: ALTER TABLE ADD COLUMN with DEFAULT on a large table (5000000 rows) is blocked
+HINT:  Adding a column with a volatile default rewrites the whole table. Add the column without a default first, then backfill in batches; raise pg_savior.large_table_threshold_rows; or set pg_savior.bypass = on. Run ANALYZE if the row estimate looks wrong.
+```
+
+The ADD COLUMN guard is conservative — it blocks any DEFAULT on a large table, even non-volatile ones that PG14+ handles via fast-default and would not actually rewrite. If you frequently add non-volatile defaults, raise `pg_savior.large_table_threshold_rows` or use bypass.
 
 ## Tests
 
@@ -151,10 +168,12 @@ If you change a test's SQL, regenerate its expected output:
 
 ## How it works
 
-pg_savior installs two hooks:
+pg_savior installs three hooks:
 
 1. **`post_parse_analyze_hook`** — fires after parse-analyze, before planning. Inspects the `Query` tree: if the statement is `CMD_DELETE`/`CMD_UPDATE` and `query->jointree->quals` is `NULL` (no `WHERE`), it raises `ERROR`. Independent of plan shape; parameterized statements handled correctly; no planner work wasted on a query that will be refused.
 
 2. **`ExecutorStart_hook`** — fires after planning, before execution. If `pg_savior.max_rows_affected > 0`, reads the planner's row estimate from the source plan beneath the `ModifyTable` node and raises `ERROR` if it exceeds the threshold. The transaction aborts before any tuples are touched.
 
-Both checks honour `pg_savior.enabled` and `pg_savior.bypass`.
+3. **`ProcessUtility_hook`** — fires for utility statements (DDL). Refuses `CREATE INDEX` without `CONCURRENTLY`, and `ALTER TABLE ADD COLUMN ... DEFAULT` when the target table's `pg_class.reltuples` exceeds `pg_savior.large_table_threshold_rows`.
+
+All checks honour `pg_savior.enabled` and `pg_savior.bypass`.

--- a/expected/unsafe_add_column.out
+++ b/expected/unsafe_add_column.out
@@ -1,0 +1,37 @@
+LOAD 'pg_savior';
+CREATE EXTENSION IF NOT EXISTS pg_savior;
+NOTICE:  extension "pg_savior" already exists, skipping
+-- Lower the threshold so a tiny test table counts as "large"
+SET pg_savior.large_table_threshold_rows = 10;
+-- Small table (under threshold): ADD COLUMN with default is allowed
+CREATE TABLE small_emp (id int);
+INSERT INTO small_emp SELECT generate_series(1, 5);
+ANALYZE small_emp;
+ALTER TABLE small_emp ADD COLUMN status text DEFAULT 'active';
+SELECT status FROM small_emp LIMIT 1;
+ status 
+--------
+ active
+(1 row)
+
+DROP TABLE small_emp;
+-- Large table (over threshold): ADD COLUMN with default is blocked
+CREATE TABLE big_emp (id int);
+INSERT INTO big_emp SELECT generate_series(1, 100);
+ANALYZE big_emp;
+ALTER TABLE big_emp ADD COLUMN status text DEFAULT 'active';
+ERROR:  pg_savior: ALTER TABLE ADD COLUMN with DEFAULT on a large table (100 rows) is blocked
+HINT:  Adding a column with a volatile default rewrites the whole table. Add the column without a default first, then backfill in batches; raise pg_savior.large_table_threshold_rows; or set pg_savior.bypass = on. Run ANALYZE if the row estimate looks wrong.
+-- ADD COLUMN without default: always allowed (no rewrite risk)
+ALTER TABLE big_emp ADD COLUMN status text;
+-- Same large table: bypass overrides
+SET pg_savior.bypass = on;
+ALTER TABLE big_emp ADD COLUMN flag text DEFAULT 'set';
+RESET pg_savior.bypass;
+-- Multiple commands in one ALTER: blocked if any AddColumn has a default
+ALTER TABLE big_emp ADD COLUMN x1 int, ADD COLUMN x2 int DEFAULT 0;
+ERROR:  pg_savior: ALTER TABLE ADD COLUMN with DEFAULT on a large table (100 rows) is blocked
+HINT:  Adding a column with a volatile default rewrites the whole table. Add the column without a default first, then backfill in batches; raise pg_savior.large_table_threshold_rows; or set pg_savior.bypass = on. Run ANALYZE if the row estimate looks wrong.
+-- Multiple commands without any default: allowed
+ALTER TABLE big_emp ADD COLUMN y1 int, ADD COLUMN y2 int;
+DROP TABLE big_emp;

--- a/expected/unsafe_create_index.out
+++ b/expected/unsafe_create_index.out
@@ -1,0 +1,25 @@
+LOAD 'pg_savior';
+CREATE EXTENSION IF NOT EXISTS pg_savior;
+NOTICE:  extension "pg_savior" already exists, skipping
+CREATE TABLE emp (id int);
+INSERT INTO emp VALUES (1);
+-- Plain CREATE INDEX is blocked
+CREATE INDEX emp_id_idx ON emp (id);
+ERROR:  pg_savior: CREATE INDEX without CONCURRENTLY is blocked
+HINT:  Use CREATE INDEX CONCURRENTLY (it cannot run in a transaction block), or set pg_savior.bypass = on for this session.
+-- CONCURRENTLY allowed (must be outside a txn block; pg_regress runs each
+-- file in its own session and each statement is auto-committed unless
+-- explicitly wrapped, so this is fine)
+CREATE INDEX CONCURRENTLY emp_id_idx ON emp (id);
+DROP INDEX emp_id_idx;
+-- Bypass overrides the check
+SET pg_savior.bypass = on;
+CREATE INDEX emp_id_idx ON emp (id);
+DROP INDEX emp_id_idx;
+RESET pg_savior.bypass;
+-- Disabled: also allowed
+SET pg_savior.enabled = off;
+CREATE INDEX emp_id_idx ON emp (id);
+DROP INDEX emp_id_idx;
+SET pg_savior.enabled = on;
+DROP TABLE emp;

--- a/pg_savior.c
+++ b/pg_savior.c
@@ -2,11 +2,14 @@
 #include <postgres.h>
 #include <fmgr.h>
 // clang-format on
+#include "access/relation.h"
 #include "executor/executor.h"
 #include "nodes/nodes.h"
 #include "nodes/parsenodes.h"
 #include "parser/analyze.h"
+#include "tcop/utility.h"
 #include "utils/guc.h"
+#include "utils/rel.h"
 
 PG_MODULE_MAGIC;
 
@@ -14,10 +17,12 @@ void _PG_init(void);
 
 static post_parse_analyze_hook_type prev_post_parse_analyze_hook = NULL;
 static ExecutorStart_hook_type prev_ExecutorStart_hook = NULL;
+static ProcessUtility_hook_type prev_ProcessUtility_hook = NULL;
 
 static bool pg_savior_enabled = true;
 static bool pg_savior_bypass = false;
 static int  pg_savior_max_rows_affected = 0;
+static int  pg_savior_large_table_threshold_rows = 1000000;
 
 static void
 pg_savior_post_parse_analyze(ParseState *pstate, Query *query, JumbleState *jstate)
@@ -76,6 +81,133 @@ pg_savior_ExecutorStart(QueryDesc *queryDesc, int eflags)
 		standard_ExecutorStart(queryDesc, eflags);
 }
 
+/*
+ * Look up reltuples for a relation by RangeVar, returning -1 if the relation
+ * cannot be opened (does not exist, lacks privileges). Caller must already be
+ * inside a transaction (which is true in any utility-statement context).
+ */
+static double
+pg_savior_relation_tuples(RangeVar *relation)
+{
+	Relation	rel;
+	double		reltuples;
+
+	rel = relation_openrv_extended(relation, AccessShareLock, true);
+	if (rel == NULL)
+		return -1;
+
+	reltuples = rel->rd_rel->reltuples;
+	relation_close(rel, AccessShareLock);
+	return reltuples;
+}
+
+static void
+pg_savior_check_create_index(IndexStmt *stmt)
+{
+	if (stmt->concurrent)
+		return;
+
+	ereport(ERROR,
+			(errcode(ERRCODE_RAISE_EXCEPTION),
+			 errmsg("pg_savior: CREATE INDEX without CONCURRENTLY is blocked"),
+			 errhint("Use CREATE INDEX CONCURRENTLY (it cannot run in a transaction block), "
+					 "or set pg_savior.bypass = on for this session.")));
+}
+
+/*
+ * Does this ColumnDef include a DEFAULT clause? The parser represents
+ * column-level DEFAULTs as Constraint nodes with contype = CONSTR_DEFAULT
+ * in col->constraints (not in raw_default, which is reserved for cooked
+ * defaults inherited via CREATE TABLE LIKE etc.).
+ */
+static bool
+column_has_default(ColumnDef *col)
+{
+	ListCell *lc;
+
+	if (col == NULL)
+		return false;
+
+	if (col->raw_default != NULL || col->cooked_default != NULL)
+		return true;
+
+	foreach (lc, col->constraints)
+	{
+		Constraint *con = (Constraint *) lfirst(lc);
+
+		if (con->contype == CONSTR_DEFAULT)
+			return true;
+	}
+	return false;
+}
+
+static void
+pg_savior_check_alter_table(AlterTableStmt *stmt)
+{
+	ListCell   *lc;
+	double		reltuples = -2;	/* -2 = not yet looked up; -1 = lookup failed */
+
+	foreach (lc, stmt->cmds)
+	{
+		AlterTableCmd *cmd = (AlterTableCmd *) lfirst(lc);
+		ColumnDef  *col;
+
+		if (cmd->subtype != AT_AddColumn)
+			continue;
+
+		col = (ColumnDef *) cmd->def;
+		if (!column_has_default(col))
+			continue;
+
+		/* Lazy lookup: only inspect the relation once, only if needed */
+		if (reltuples == -2)
+			reltuples = pg_savior_relation_tuples(stmt->relation);
+
+		if (reltuples < 0)	/* relation lookup failed; let standard handler error */
+			return;
+
+		if (reltuples <= pg_savior_large_table_threshold_rows)
+			return;
+
+		ereport(ERROR,
+				(errcode(ERRCODE_RAISE_EXCEPTION),
+				 errmsg("pg_savior: ALTER TABLE ADD COLUMN with DEFAULT on a large table (%.0f rows) is blocked",
+						reltuples),
+				 errhint("Adding a column with a volatile default rewrites the whole table. "
+						 "Add the column without a default first, then backfill in batches; "
+						 "raise pg_savior.large_table_threshold_rows; or set pg_savior.bypass = on. "
+						 "Run ANALYZE if the row estimate looks wrong.")));
+	}
+}
+
+static void
+pg_savior_ProcessUtility(PlannedStmt *pstmt,
+						 const char *queryString,
+						 bool readOnlyTree,
+						 ProcessUtilityContext context,
+						 ParamListInfo params,
+						 QueryEnvironment *queryEnv,
+						 DestReceiver *dest,
+						 QueryCompletion *qc)
+{
+	Node *parsetree = pstmt->utilityStmt;
+
+	if (pg_savior_enabled && !pg_savior_bypass)
+	{
+		if (IsA(parsetree, IndexStmt))
+			pg_savior_check_create_index((IndexStmt *) parsetree);
+		else if (IsA(parsetree, AlterTableStmt))
+			pg_savior_check_alter_table((AlterTableStmt *) parsetree);
+	}
+
+	if (prev_ProcessUtility_hook)
+		prev_ProcessUtility_hook(pstmt, queryString, readOnlyTree, context,
+								 params, queryEnv, dest, qc);
+	else
+		standard_ProcessUtility(pstmt, queryString, readOnlyTree, context,
+								params, queryEnv, dest, qc);
+}
+
 void
 _PG_init(void)
 {
@@ -108,9 +240,23 @@ _PG_init(void)
 							0,
 							NULL, NULL, NULL);
 
+	DefineCustomIntVariable("pg_savior.large_table_threshold_rows",
+							"Tables with more rows than this are considered \"large\" for the DDL guards.",
+							NULL,
+							&pg_savior_large_table_threshold_rows,
+							1000000,
+							0,
+							INT_MAX,
+							PGC_USERSET,
+							0,
+							NULL, NULL, NULL);
+
 	prev_post_parse_analyze_hook = post_parse_analyze_hook;
 	post_parse_analyze_hook = pg_savior_post_parse_analyze;
 
 	prev_ExecutorStart_hook = ExecutorStart_hook;
 	ExecutorStart_hook = pg_savior_ExecutorStart;
+
+	prev_ProcessUtility_hook = ProcessUtility_hook;
+	ProcessUtility_hook = pg_savior_ProcessUtility;
 }

--- a/sql/unsafe_add_column.sql
+++ b/sql/unsafe_add_column.sql
@@ -1,0 +1,35 @@
+LOAD 'pg_savior';
+CREATE EXTENSION IF NOT EXISTS pg_savior;
+
+-- Lower the threshold so a tiny test table counts as "large"
+SET pg_savior.large_table_threshold_rows = 10;
+
+-- Small table (under threshold): ADD COLUMN with default is allowed
+CREATE TABLE small_emp (id int);
+INSERT INTO small_emp SELECT generate_series(1, 5);
+ANALYZE small_emp;
+ALTER TABLE small_emp ADD COLUMN status text DEFAULT 'active';
+SELECT status FROM small_emp LIMIT 1;
+DROP TABLE small_emp;
+
+-- Large table (over threshold): ADD COLUMN with default is blocked
+CREATE TABLE big_emp (id int);
+INSERT INTO big_emp SELECT generate_series(1, 100);
+ANALYZE big_emp;
+ALTER TABLE big_emp ADD COLUMN status text DEFAULT 'active';
+
+-- ADD COLUMN without default: always allowed (no rewrite risk)
+ALTER TABLE big_emp ADD COLUMN status text;
+
+-- Same large table: bypass overrides
+SET pg_savior.bypass = on;
+ALTER TABLE big_emp ADD COLUMN flag text DEFAULT 'set';
+RESET pg_savior.bypass;
+
+-- Multiple commands in one ALTER: blocked if any AddColumn has a default
+ALTER TABLE big_emp ADD COLUMN x1 int, ADD COLUMN x2 int DEFAULT 0;
+
+-- Multiple commands without any default: allowed
+ALTER TABLE big_emp ADD COLUMN y1 int, ADD COLUMN y2 int;
+
+DROP TABLE big_emp;

--- a/sql/unsafe_create_index.sql
+++ b/sql/unsafe_create_index.sql
@@ -1,0 +1,28 @@
+LOAD 'pg_savior';
+CREATE EXTENSION IF NOT EXISTS pg_savior;
+
+CREATE TABLE emp (id int);
+INSERT INTO emp VALUES (1);
+
+-- Plain CREATE INDEX is blocked
+CREATE INDEX emp_id_idx ON emp (id);
+
+-- CONCURRENTLY allowed (must be outside a txn block; pg_regress runs each
+-- file in its own session and each statement is auto-committed unless
+-- explicitly wrapped, so this is fine)
+CREATE INDEX CONCURRENTLY emp_id_idx ON emp (id);
+DROP INDEX emp_id_idx;
+
+-- Bypass overrides the check
+SET pg_savior.bypass = on;
+CREATE INDEX emp_id_idx ON emp (id);
+DROP INDEX emp_id_idx;
+RESET pg_savior.bypass;
+
+-- Disabled: also allowed
+SET pg_savior.enabled = off;
+CREATE INDEX emp_id_idx ON emp (id);
+DROP INDEX emp_id_idx;
+SET pg_savior.enabled = on;
+
+DROP TABLE emp;


### PR DESCRIPTION
## Summary
Adds a `ProcessUtility_hook` with two new checks:

1. **`CREATE INDEX` without `CONCURRENTLY`** → `ERROR`. Always blocks. The non-concurrent variant takes `ACCESS EXCLUSIVE` on the table for the entire build, freezing reads and writes.

2. **`ALTER TABLE ADD COLUMN ... DEFAULT`** → `ERROR` when `pg_class.reltuples` for the target table exceeds `pg_savior.large_table_threshold_rows` (new GUC, default `1_000_000`). Catches the classic "I added a `timestamp DEFAULT now()` column to a billion-row table and the migration ran for 4 hours" foot-gun.

Both checks honour `pg_savior.enabled` and `pg_savior.bypass`.

## New GUC
| GUC | Default | Effect |
|---|---|---|
| `pg_savior.large_table_threshold_rows` | `1_000_000` | Tables with `reltuples` over this are "large" for DDL guards |

## Caught during implementation
First capture run silently passed the ADD COLUMN test — `raw_default` was always NULL. Turns out the parser puts column-level `DEFAULT` in `col->constraints[]` as a `Constraint(contype = CONSTR_DEFAULT)`, not in `ColumnDef.raw_default` (that field is reserved for cooked defaults inherited via `CREATE TABLE LIKE`). Fixed at [pg_savior.c — `column_has_default()`](pg_savior.c).

This was also why I made the rule "eyeball every captured `expected/*.out` for the actual `ERROR:` strings before declaring a test green" — same trap as the row-count threshold PR.

## Conservative design choice
The ADD COLUMN check does not distinguish volatile from non-volatile defaults. Non-volatile defaults on PG14+ are stored as metadata (no rewrite); volatile defaults force a full rewrite. Detecting volatility on a raw (un-analyzed) expression tree is fiddly. So this PR errs on the side of "block any default on a large table" with `pg_savior.bypass = on` as the escape hatch. Volatility detection is a possible follow-up if false-positives become annoying.

## Test plan
- [x] `CREATE INDEX` blocked, `CREATE INDEX CONCURRENTLY` allowed, bypass works, disabled works
- [x] ADD COLUMN with default on small table allowed, on large table blocked
- [x] ADD COLUMN without default always allowed
- [x] Multi-cmd ALTER TABLE: blocked if *any* AddColumn has a default; allowed if none do
- [x] Bypass overrides
- [x] All 8 tests pass on PG14, PG16, PG17

🤖 Generated with [Claude Code](https://claude.com/claude-code)