### PR TITLE
Add DROP TABLE (large) and DROP DATABASE guards

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 MODULES = pg_savior
 EXTENSION = pg_savior
 DATA = pg_savior--0.0.1.sql
-REGRESS = basic delete_block update_block bypass disabled max_rows unsafe_create_index unsafe_add_column
+REGRESS = basic delete_block update_block bypass disabled max_rows unsafe_create_index unsafe_add_column unsafe_drop_table unsafe_drop_database
 
 PG_CONFIG = pg_config
 PGXS := $(shell $(PG_CONFIG) --pgxs)

--- a/README.md
+++ b/README.md
@@ -13,9 +13,11 @@ Under active development. Pre-1.0. Not production-ready.
 - [x] Row-count threshold guard (`pg_savior.max_rows_affected`)
 - [x] Block `CREATE INDEX` without `CONCURRENTLY`
 - [x] Block `ALTER TABLE ADD COLUMN ... DEFAULT` on large tables
+- [x] Block `DROP TABLE` on large tables
+- [x] Block `DROP DATABASE`
 - [x] Per-session bypass GUC (`pg_savior.bypass`)
 - [x] Global on/off GUC (`pg_savior.enabled`)
-- [ ] Block other destructive DDL (`DROP TABLE`, `TRUNCATE`, `DROP DATABASE`)
+- [ ] Block `TRUNCATE`
 - [ ] Per-table opt-out via reloptions
 
 ## Installation
@@ -129,6 +131,14 @@ HINT:  Use CREATE INDEX CONCURRENTLY (it cannot run in a transaction block), or 
 postgres=# ALTER TABLE big_emp ADD COLUMN status text DEFAULT 'active';
 ERROR:  pg_savior: ALTER TABLE ADD COLUMN with DEFAULT on a large table (5000000 rows) is blocked
 HINT:  Adding a column with a volatile default rewrites the whole table. Add the column without a default first, then backfill in batches; raise pg_savior.large_table_threshold_rows; or set pg_savior.bypass = on. Run ANALYZE if the row estimate looks wrong.
+
+postgres=# DROP TABLE big_emp;
+ERROR:  pg_savior: DROP TABLE on a large table "big_emp" (5000000 rows) is blocked
+HINT:  Verify the target, raise pg_savior.large_table_threshold_rows, or set pg_savior.bypass = on. Run ANALYZE if the row estimate looks wrong.
+
+postgres=# DROP DATABASE production_db;
+ERROR:  pg_savior: DROP DATABASE "production_db" is blocked
+HINT:  Set pg_savior.bypass = on for this session if you really mean it.
 ```
 
 The ADD COLUMN guard is conservative — it blocks any DEFAULT on a large table, even non-volatile ones that PG14+ handles via fast-default and would not actually rewrite. If you frequently add non-volatile defaults, raise `pg_savior.large_table_threshold_rows` or use bypass.
@@ -174,6 +184,10 @@ pg_savior installs three hooks:
 
 2. **`ExecutorStart_hook`** — fires after planning, before execution. If `pg_savior.max_rows_affected > 0`, reads the planner's row estimate from the source plan beneath the `ModifyTable` node and raises `ERROR` if it exceeds the threshold. The transaction aborts before any tuples are touched.
 
-3. **`ProcessUtility_hook`** — fires for utility statements (DDL). Refuses `CREATE INDEX` without `CONCURRENTLY`, and `ALTER TABLE ADD COLUMN ... DEFAULT` when the target table's `pg_class.reltuples` exceeds `pg_savior.large_table_threshold_rows`.
+3. **`ProcessUtility_hook`** — fires for utility statements (DDL). Refuses:
+   - `CREATE INDEX` without `CONCURRENTLY` (always)
+   - `ALTER TABLE ADD COLUMN ... DEFAULT` when the target table's `pg_class.reltuples` exceeds `pg_savior.large_table_threshold_rows`
+   - `DROP TABLE` when any target table's `pg_class.reltuples` exceeds the same threshold (multi-table drops blocked if *any* target is large)
+   - `DROP DATABASE` (always)
 
 All checks honour `pg_savior.enabled` and `pg_savior.bypass`.

--- a/expected/unsafe_add_column.out
+++ b/expected/unsafe_add_column.out
@@ -34,4 +34,7 @@ ERROR:  pg_savior: ALTER TABLE ADD COLUMN with DEFAULT on a large table (100 row
 HINT:  Adding a column with a volatile default rewrites the whole table. Add the column without a default first, then backfill in batches; raise pg_savior.large_table_threshold_rows; or set pg_savior.bypass = on. Run ANALYZE if the row estimate looks wrong.
 -- Multiple commands without any default: allowed
 ALTER TABLE big_emp ADD COLUMN y1 int, ADD COLUMN y2 int;
+-- Cleanup: bypass the new DROP TABLE guard since we lowered the threshold
+SET pg_savior.bypass = on;
 DROP TABLE big_emp;
+RESET pg_savior.bypass;

--- a/expected/unsafe_drop_database.out
+++ b/expected/unsafe_drop_database.out
@@ -1,0 +1,29 @@
+LOAD 'pg_savior';
+CREATE EXTENSION IF NOT EXISTS pg_savior;
+NOTICE:  extension "pg_savior" already exists, skipping
+-- Setup: ensure the test database is gone, then create it. Do both with
+-- bypass on so we don't hit the guard during setup.
+SET pg_savior.bypass = on;
+DROP DATABASE IF EXISTS pg_savior_drop_test_db;
+NOTICE:  database "pg_savior_drop_test_db" does not exist, skipping
+CREATE DATABASE pg_savior_drop_test_db;
+RESET pg_savior.bypass;
+-- Default: DROP DATABASE always blocked
+DROP DATABASE pg_savior_drop_test_db;
+ERROR:  pg_savior: DROP DATABASE "pg_savior_drop_test_db" is blocked
+HINT:  Set pg_savior.bypass = on for this session if you really mean it.
+-- DROP DATABASE IF EXISTS: still blocked (we refuse before standard handler decides)
+DROP DATABASE IF EXISTS pg_savior_drop_test_db;
+ERROR:  pg_savior: DROP DATABASE "pg_savior_drop_test_db" is blocked
+HINT:  Set pg_savior.bypass = on for this session if you really mean it.
+-- Bypass: succeeds
+SET pg_savior.bypass = on;
+DROP DATABASE pg_savior_drop_test_db;
+RESET pg_savior.bypass;
+-- Disabled: also allowed
+SET pg_savior.bypass = on;
+CREATE DATABASE pg_savior_drop_test_db;
+RESET pg_savior.bypass;
+SET pg_savior.enabled = off;
+DROP DATABASE pg_savior_drop_test_db;
+SET pg_savior.enabled = on;

--- a/expected/unsafe_drop_table.out
+++ b/expected/unsafe_drop_table.out
@@ -1,0 +1,66 @@
+LOAD 'pg_savior';
+CREATE EXTENSION IF NOT EXISTS pg_savior;
+NOTICE:  extension "pg_savior" already exists, skipping
+-- Lower threshold so a tiny test table counts as "large"
+SET pg_savior.large_table_threshold_rows = 10;
+-- Small table (under threshold): DROP succeeds
+CREATE TABLE small_emp (id int);
+INSERT INTO small_emp SELECT generate_series(1, 5);
+ANALYZE small_emp;
+DROP TABLE small_emp;
+-- Large table (over threshold): DROP blocked
+CREATE TABLE big_emp (id int);
+INSERT INTO big_emp SELECT generate_series(1, 100);
+ANALYZE big_emp;
+DROP TABLE big_emp;
+ERROR:  pg_savior: DROP TABLE on a large table "big_emp" (100 rows) is blocked
+HINT:  Verify the target, raise pg_savior.large_table_threshold_rows, or set pg_savior.bypass = on. Run ANALYZE if the row estimate looks wrong.
+-- DROP TABLE IF EXISTS on a missing table: allowed (lookup miss, no check fires)
+DROP TABLE IF EXISTS does_not_exist;
+NOTICE:  table "does_not_exist" does not exist, skipping
+-- Multi-target DROP: blocked if any target is large
+CREATE TABLE small_a (id int);
+INSERT INTO small_a VALUES (1);
+ANALYZE small_a;
+DROP TABLE small_a, big_emp;
+ERROR:  pg_savior: DROP TABLE on a large table "big_emp" (100 rows) is blocked
+HINT:  Verify the target, raise pg_savior.large_table_threshold_rows, or set pg_savior.bypass = on. Run ANALYZE if the row estimate looks wrong.
+-- Both should still exist after the failed multi-drop
+SELECT count(*) AS small_a_rows FROM small_a;
+ small_a_rows 
+--------------
+            1
+(1 row)
+
+SELECT count(*) AS big_emp_rows FROM big_emp;
+ big_emp_rows 
+--------------
+          100
+(1 row)
+
+-- Multi-target DROP where all are small: succeeds
+CREATE TABLE small_b (id int);
+INSERT INTO small_b VALUES (1);
+ANALYZE small_b;
+DROP TABLE small_a, small_b;
+-- Bypass overrides
+SET pg_savior.bypass = on;
+DROP TABLE big_emp;
+RESET pg_savior.bypass;
+-- Disabled: also allowed
+CREATE TABLE big_emp (id int);
+INSERT INTO big_emp SELECT generate_series(1, 100);
+ANALYZE big_emp;
+SET pg_savior.enabled = off;
+DROP TABLE big_emp;
+SET pg_savior.enabled = on;
+-- DROP VIEW (not OBJECT_TABLE): not affected by this guard
+CREATE TABLE v_src (id int);
+INSERT INTO v_src SELECT generate_series(1, 100);
+ANALYZE v_src;
+CREATE VIEW v_test AS SELECT * FROM v_src;
+DROP VIEW v_test;
+-- Cleanup
+SET pg_savior.bypass = on;
+DROP TABLE v_src;
+RESET pg_savior.bypass;

--- a/pg_savior.c
+++ b/pg_savior.c
@@ -3,6 +3,7 @@
 #include <fmgr.h>
 // clang-format on
 #include "access/relation.h"
+#include "catalog/namespace.h"
 #include "executor/executor.h"
 #include "nodes/nodes.h"
 #include "nodes/parsenodes.h"
@@ -181,6 +182,46 @@ pg_savior_check_alter_table(AlterTableStmt *stmt)
 }
 
 static void
+pg_savior_check_drop(DropStmt *stmt)
+{
+	ListCell *lc;
+
+	/* Only guard DROP TABLE; other relkinds (view, sequence, ...) pass through */
+	if (stmt->removeType != OBJECT_TABLE)
+		return;
+
+	foreach (lc, stmt->objects)
+	{
+		List	   *name_list = (List *) lfirst(lc);
+		RangeVar   *rv = makeRangeVarFromNameList(name_list);
+		double		reltuples = pg_savior_relation_tuples(rv);
+
+		/* Relation does not exist (or no privilege): let standard handler decide */
+		if (reltuples < 0)
+			continue;
+
+		if (reltuples <= pg_savior_large_table_threshold_rows)
+			continue;
+
+		ereport(ERROR,
+				(errcode(ERRCODE_RAISE_EXCEPTION),
+				 errmsg("pg_savior: DROP TABLE on a large table \"%s\" (%.0f rows) is blocked",
+						rv->relname, reltuples),
+				 errhint("Verify the target, raise pg_savior.large_table_threshold_rows, "
+						 "or set pg_savior.bypass = on. Run ANALYZE if the row estimate looks wrong.")));
+	}
+}
+
+static void
+pg_savior_check_drop_database(DropdbStmt *stmt)
+{
+	ereport(ERROR,
+			(errcode(ERRCODE_RAISE_EXCEPTION),
+			 errmsg("pg_savior: DROP DATABASE \"%s\" is blocked", stmt->dbname),
+			 errhint("Set pg_savior.bypass = on for this session if you really mean it.")));
+}
+
+static void
 pg_savior_ProcessUtility(PlannedStmt *pstmt,
 						 const char *queryString,
 						 bool readOnlyTree,
@@ -198,6 +239,10 @@ pg_savior_ProcessUtility(PlannedStmt *pstmt,
 			pg_savior_check_create_index((IndexStmt *) parsetree);
 		else if (IsA(parsetree, AlterTableStmt))
 			pg_savior_check_alter_table((AlterTableStmt *) parsetree);
+		else if (IsA(parsetree, DropStmt))
+			pg_savior_check_drop((DropStmt *) parsetree);
+		else if (IsA(parsetree, DropdbStmt))
+			pg_savior_check_drop_database((DropdbStmt *) parsetree);
 	}
 
 	if (prev_ProcessUtility_hook)

--- a/sql/unsafe_add_column.sql
+++ b/sql/unsafe_add_column.sql
@@ -32,4 +32,7 @@ ALTER TABLE big_emp ADD COLUMN x1 int, ADD COLUMN x2 int DEFAULT 0;
 -- Multiple commands without any default: allowed
 ALTER TABLE big_emp ADD COLUMN y1 int, ADD COLUMN y2 int;
 
+-- Cleanup: bypass the new DROP TABLE guard since we lowered the threshold
+SET pg_savior.bypass = on;
 DROP TABLE big_emp;
+RESET pg_savior.bypass;

--- a/sql/unsafe_drop_database.sql
+++ b/sql/unsafe_drop_database.sql
@@ -1,0 +1,28 @@
+LOAD 'pg_savior';
+CREATE EXTENSION IF NOT EXISTS pg_savior;
+
+-- Setup: ensure the test database is gone, then create it. Do both with
+-- bypass on so we don't hit the guard during setup.
+SET pg_savior.bypass = on;
+DROP DATABASE IF EXISTS pg_savior_drop_test_db;
+CREATE DATABASE pg_savior_drop_test_db;
+RESET pg_savior.bypass;
+
+-- Default: DROP DATABASE always blocked
+DROP DATABASE pg_savior_drop_test_db;
+
+-- DROP DATABASE IF EXISTS: still blocked (we refuse before standard handler decides)
+DROP DATABASE IF EXISTS pg_savior_drop_test_db;
+
+-- Bypass: succeeds
+SET pg_savior.bypass = on;
+DROP DATABASE pg_savior_drop_test_db;
+RESET pg_savior.bypass;
+
+-- Disabled: also allowed
+SET pg_savior.bypass = on;
+CREATE DATABASE pg_savior_drop_test_db;
+RESET pg_savior.bypass;
+SET pg_savior.enabled = off;
+DROP DATABASE pg_savior_drop_test_db;
+SET pg_savior.enabled = on;

--- a/sql/unsafe_drop_table.sql
+++ b/sql/unsafe_drop_table.sql
@@ -1,0 +1,60 @@
+LOAD 'pg_savior';
+CREATE EXTENSION IF NOT EXISTS pg_savior;
+
+-- Lower threshold so a tiny test table counts as "large"
+SET pg_savior.large_table_threshold_rows = 10;
+
+-- Small table (under threshold): DROP succeeds
+CREATE TABLE small_emp (id int);
+INSERT INTO small_emp SELECT generate_series(1, 5);
+ANALYZE small_emp;
+DROP TABLE small_emp;
+
+-- Large table (over threshold): DROP blocked
+CREATE TABLE big_emp (id int);
+INSERT INTO big_emp SELECT generate_series(1, 100);
+ANALYZE big_emp;
+DROP TABLE big_emp;
+
+-- DROP TABLE IF EXISTS on a missing table: allowed (lookup miss, no check fires)
+DROP TABLE IF EXISTS does_not_exist;
+
+-- Multi-target DROP: blocked if any target is large
+CREATE TABLE small_a (id int);
+INSERT INTO small_a VALUES (1);
+ANALYZE small_a;
+DROP TABLE small_a, big_emp;
+-- Both should still exist after the failed multi-drop
+SELECT count(*) AS small_a_rows FROM small_a;
+SELECT count(*) AS big_emp_rows FROM big_emp;
+
+-- Multi-target DROP where all are small: succeeds
+CREATE TABLE small_b (id int);
+INSERT INTO small_b VALUES (1);
+ANALYZE small_b;
+DROP TABLE small_a, small_b;
+
+-- Bypass overrides
+SET pg_savior.bypass = on;
+DROP TABLE big_emp;
+RESET pg_savior.bypass;
+
+-- Disabled: also allowed
+CREATE TABLE big_emp (id int);
+INSERT INTO big_emp SELECT generate_series(1, 100);
+ANALYZE big_emp;
+SET pg_savior.enabled = off;
+DROP TABLE big_emp;
+SET pg_savior.enabled = on;
+
+-- DROP VIEW (not OBJECT_TABLE): not affected by this guard
+CREATE TABLE v_src (id int);
+INSERT INTO v_src SELECT generate_series(1, 100);
+ANALYZE v_src;
+CREATE VIEW v_test AS SELECT * FROM v_src;
+DROP VIEW v_test;
+
+-- Cleanup
+SET pg_savior.bypass = on;
+DROP TABLE v_src;
+RESET pg_savior.bypass;


### PR DESCRIPTION
## Summary
Two more checks on the existing `ProcessUtility_hook`:

1. **`DROP TABLE`** → `ERROR` when any target table's `pg_class.reltuples` exceeds `pg_savior.large_table_threshold_rows`. Multi-table drops (`DROP TABLE a, b, c`) blocked if *any* target is large.
2. **`DROP DATABASE`** → always `ERROR` when enabled and not bypassed.

Both reuse the existing `pg_savior.large_table_threshold_rows` GUC and honour `pg_savior.enabled` / `pg_savior.bypass`. No new GUCs.

## Edge cases handled
- `DROP TABLE IF EXISTS missing_table` — lookup returns "not found", check skips, standard handler emits its usual "skipping" notice
- `DROP TABLE foo, bar, baz` where bar is large — entire statement refused, none dropped
- `DROP VIEW` and other non-table drops — pass through (we only fire on `removeType == OBJECT_TABLE`)
- `DROP DATABASE IF EXISTS x` — still blocked (we refuse before standard handler decides)
- `DROP TABLE big_emp` in [sql/unsafe_add_column.sql](sql/unsafe_add_column.sql) — that test lowers the threshold to 10 and ends with `DROP TABLE big_emp` (100 rows). Wrapped the final drop in `bypass` so the existing test still passes.

## Test plan
- [x] New `unsafe_drop_table` regression test: small allowed, large blocked, IF EXISTS passes through, multi-target blocking, multi-target small succeeds, bypass, disabled, DROP VIEW unaffected
- [x] New `unsafe_drop_database` regression test: blocked, IF EXISTS still blocked, bypass succeeds, disabled allows
- [x] All 10 tests pass on PG14, PG16, PG17
- [x] Eyeballed every captured `expected/*.out` for actual `ERROR:` strings before merging

🤖 Generated with [Claude Code](https://claude.com/claude-code)