### PR TITLE
Add TRUNCATE and ALTER COLUMN TYPE guards (large tables)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 MODULES = pg_savior
 EXTENSION = pg_savior
 DATA = pg_savior--0.0.1.sql
-REGRESS = basic delete_block update_block bypass disabled max_rows unsafe_create_index unsafe_add_column unsafe_drop_table unsafe_drop_database
+REGRESS = basic delete_block update_block bypass disabled max_rows unsafe_create_index unsafe_add_column unsafe_drop_table unsafe_drop_database unsafe_truncate unsafe_alter_column_type
 
 PG_CONFIG = pg_config
 PGXS := $(shell $(PG_CONFIG) --pgxs)

--- a/README.md
+++ b/README.md
@@ -13,12 +13,14 @@ Under active development. Pre-1.0. Not production-ready.
 - [x] Row-count threshold guard (`pg_savior.max_rows_affected`)
 - [x] Block `CREATE INDEX` without `CONCURRENTLY`
 - [x] Block `ALTER TABLE ADD COLUMN ... DEFAULT` on large tables
+- [x] Block `ALTER TABLE ALTER COLUMN TYPE` on large tables
+- [x] Block `TRUNCATE` on large tables
 - [x] Block `DROP TABLE` on large tables
 - [x] Block `DROP DATABASE`
 - [x] Per-session bypass GUC (`pg_savior.bypass`)
 - [x] Global on/off GUC (`pg_savior.enabled`)
-- [ ] Block `TRUNCATE`
 - [ ] Per-table opt-out via reloptions
+- [ ] Volatility detection for `ADD COLUMN` (only block volatile defaults)
 
 ## Installation
 
@@ -139,6 +141,14 @@ HINT:  Verify the target, raise pg_savior.large_table_threshold_rows, or set pg_
 postgres=# DROP DATABASE production_db;
 ERROR:  pg_savior: DROP DATABASE "production_db" is blocked
 HINT:  Set pg_savior.bypass = on for this session if you really mean it.
+
+postgres=# TRUNCATE big_emp;
+ERROR:  pg_savior: TRUNCATE on a large table "big_emp" (5000000 rows) is blocked
+HINT:  Verify the target, raise pg_savior.large_table_threshold_rows, or set pg_savior.bypass = on. Run ANALYZE if the row estimate looks wrong.
+
+postgres=# ALTER TABLE big_emp ALTER COLUMN id TYPE bigint;
+ERROR:  pg_savior: ALTER TABLE ALTER COLUMN TYPE on a large table (5000000 rows) is blocked
+HINT:  This operation rewrites the whole table. Plan a batched migration; raise pg_savior.large_table_threshold_rows; or set pg_savior.bypass = on. Run ANALYZE if the row estimate looks wrong.
 ```
 
 The ADD COLUMN guard is conservative — it blocks any DEFAULT on a large table, even non-volatile ones that PG14+ handles via fast-default and would not actually rewrite. If you frequently add non-volatile defaults, raise `pg_savior.large_table_threshold_rows` or use bypass.
@@ -186,8 +196,12 @@ pg_savior installs three hooks:
 
 3. **`ProcessUtility_hook`** — fires for utility statements (DDL). Refuses:
    - `CREATE INDEX` without `CONCURRENTLY` (always)
-   - `ALTER TABLE ADD COLUMN ... DEFAULT` when the target table's `pg_class.reltuples` exceeds `pg_savior.large_table_threshold_rows`
-   - `DROP TABLE` when any target table's `pg_class.reltuples` exceeds the same threshold (multi-table drops blocked if *any* target is large)
+   - `ALTER TABLE ADD COLUMN ... DEFAULT` when the target table is over the threshold
+   - `ALTER TABLE ALTER COLUMN TYPE` when the target table is over the threshold (rewrites the table)
+   - `TRUNCATE` when any target table is over the threshold (multi-table truncates blocked if *any* target is large)
+   - `DROP TABLE` when any target table is over the threshold (multi-table drops blocked if *any* target is large)
    - `DROP DATABASE` (always)
+
+   "Over the threshold" means `pg_class.reltuples > pg_savior.large_table_threshold_rows`.
 
 All checks honour `pg_savior.enabled` and `pg_savior.bypass`.

--- a/expected/unsafe_add_column.out
+++ b/expected/unsafe_add_column.out
@@ -21,7 +21,7 @@ INSERT INTO big_emp SELECT generate_series(1, 100);
 ANALYZE big_emp;
 ALTER TABLE big_emp ADD COLUMN status text DEFAULT 'active';
 ERROR:  pg_savior: ALTER TABLE ADD COLUMN with DEFAULT on a large table (100 rows) is blocked
-HINT:  Adding a column with a volatile default rewrites the whole table. Add the column without a default first, then backfill in batches; raise pg_savior.large_table_threshold_rows; or set pg_savior.bypass = on. Run ANALYZE if the row estimate looks wrong.
+HINT:  This operation rewrites the whole table. Plan a batched migration; raise pg_savior.large_table_threshold_rows; or set pg_savior.bypass = on. Run ANALYZE if the row estimate looks wrong.
 -- ADD COLUMN without default: always allowed (no rewrite risk)
 ALTER TABLE big_emp ADD COLUMN status text;
 -- Same large table: bypass overrides
@@ -31,7 +31,7 @@ RESET pg_savior.bypass;
 -- Multiple commands in one ALTER: blocked if any AddColumn has a default
 ALTER TABLE big_emp ADD COLUMN x1 int, ADD COLUMN x2 int DEFAULT 0;
 ERROR:  pg_savior: ALTER TABLE ADD COLUMN with DEFAULT on a large table (100 rows) is blocked
-HINT:  Adding a column with a volatile default rewrites the whole table. Add the column without a default first, then backfill in batches; raise pg_savior.large_table_threshold_rows; or set pg_savior.bypass = on. Run ANALYZE if the row estimate looks wrong.
+HINT:  This operation rewrites the whole table. Plan a batched migration; raise pg_savior.large_table_threshold_rows; or set pg_savior.bypass = on. Run ANALYZE if the row estimate looks wrong.
 -- Multiple commands without any default: allowed
 ALTER TABLE big_emp ADD COLUMN y1 int, ADD COLUMN y2 int;
 -- Cleanup: bypass the new DROP TABLE guard since we lowered the threshold

--- a/expected/unsafe_alter_column_type.out
+++ b/expected/unsafe_alter_column_type.out
@@ -1,0 +1,35 @@
+LOAD 'pg_savior';
+CREATE EXTENSION IF NOT EXISTS pg_savior;
+NOTICE:  extension "pg_savior" already exists, skipping
+SET pg_savior.large_table_threshold_rows = 10;
+-- Small table: ALTER COLUMN TYPE allowed
+CREATE TABLE small_emp (id int);
+INSERT INTO small_emp SELECT generate_series(1, 5);
+ANALYZE small_emp;
+ALTER TABLE small_emp ALTER COLUMN id TYPE bigint;
+DROP TABLE small_emp;
+-- Large table: ALTER COLUMN TYPE blocked
+CREATE TABLE big_emp (id int, name text);
+INSERT INTO big_emp SELECT generate_series(1, 100), 'x';
+ANALYZE big_emp;
+ALTER TABLE big_emp ALTER COLUMN id TYPE bigint;
+ERROR:  pg_savior: ALTER TABLE ALTER COLUMN TYPE on a large table (100 rows) is blocked
+HINT:  This operation rewrites the whole table. Plan a batched migration; raise pg_savior.large_table_threshold_rows; or set pg_savior.bypass = on. Run ANALYZE if the row estimate looks wrong.
+-- Multi-cmd: blocked if any cmd is a type change
+ALTER TABLE big_emp ADD COLUMN extra int, ALTER COLUMN name TYPE varchar(50);
+ERROR:  pg_savior: ALTER TABLE ALTER COLUMN TYPE on a large table (100 rows) is blocked
+HINT:  This operation rewrites the whole table. Plan a batched migration; raise pg_savior.large_table_threshold_rows; or set pg_savior.bypass = on. Run ANALYZE if the row estimate looks wrong.
+-- Multi-cmd without type change or default: allowed
+ALTER TABLE big_emp ADD COLUMN y1 int, ADD COLUMN y2 int;
+-- Bypass overrides
+SET pg_savior.bypass = on;
+ALTER TABLE big_emp ALTER COLUMN id TYPE bigint;
+RESET pg_savior.bypass;
+-- Disabled also allowed
+SET pg_savior.enabled = off;
+ALTER TABLE big_emp ALTER COLUMN name TYPE varchar(100);
+SET pg_savior.enabled = on;
+-- Cleanup
+SET pg_savior.bypass = on;
+DROP TABLE big_emp;
+RESET pg_savior.bypass;

--- a/expected/unsafe_truncate.out
+++ b/expected/unsafe_truncate.out
@@ -1,0 +1,84 @@
+LOAD 'pg_savior';
+CREATE EXTENSION IF NOT EXISTS pg_savior;
+NOTICE:  extension "pg_savior" already exists, skipping
+SET pg_savior.large_table_threshold_rows = 10;
+-- Small table: TRUNCATE allowed
+CREATE TABLE small_emp (id int);
+INSERT INTO small_emp SELECT generate_series(1, 5);
+ANALYZE small_emp;
+TRUNCATE small_emp;
+SELECT count(*) AS rowcount FROM small_emp;
+ rowcount 
+----------
+        0
+(1 row)
+
+-- Large table: TRUNCATE blocked
+CREATE TABLE big_emp (id int);
+INSERT INTO big_emp SELECT generate_series(1, 100);
+ANALYZE big_emp;
+TRUNCATE big_emp;
+ERROR:  pg_savior: TRUNCATE on a large table "big_emp" (100 rows) is blocked
+HINT:  Verify the target, raise pg_savior.large_table_threshold_rows, or set pg_savior.bypass = on. Run ANALYZE if the row estimate looks wrong.
+SELECT count(*) AS rowcount FROM big_emp;
+ rowcount 
+----------
+      100
+(1 row)
+
+-- Multi-target: blocked if any large
+INSERT INTO small_emp SELECT generate_series(1, 5);
+ANALYZE small_emp;
+TRUNCATE small_emp, big_emp;
+ERROR:  pg_savior: TRUNCATE on a large table "big_emp" (100 rows) is blocked
+HINT:  Verify the target, raise pg_savior.large_table_threshold_rows, or set pg_savior.bypass = on. Run ANALYZE if the row estimate looks wrong.
+-- Both still populated
+SELECT count(*) AS small_rowcount FROM small_emp;
+ small_rowcount 
+----------------
+              5
+(1 row)
+
+SELECT count(*) AS big_rowcount FROM big_emp;
+ big_rowcount 
+--------------
+          100
+(1 row)
+
+-- Multi-target where all are small: succeeds
+CREATE TABLE small_b (id int);
+INSERT INTO small_b VALUES (1);
+ANALYZE small_b;
+TRUNCATE small_emp, small_b;
+-- TRUNCATE ... CASCADE: same logic (CASCADE doesn't affect our check)
+TRUNCATE big_emp CASCADE;
+ERROR:  pg_savior: TRUNCATE on a large table "big_emp" (100 rows) is blocked
+HINT:  Verify the target, raise pg_savior.large_table_threshold_rows, or set pg_savior.bypass = on. Run ANALYZE if the row estimate looks wrong.
+-- Bypass overrides
+SET pg_savior.bypass = on;
+TRUNCATE big_emp;
+RESET pg_savior.bypass;
+SELECT count(*) AS after_bypass FROM big_emp;
+ after_bypass 
+--------------
+            0
+(1 row)
+
+-- Disabled: also allowed
+INSERT INTO big_emp SELECT generate_series(1, 100);
+ANALYZE big_emp;
+SET pg_savior.enabled = off;
+TRUNCATE big_emp;
+SET pg_savior.enabled = on;
+SELECT count(*) AS after_disabled FROM big_emp;
+ after_disabled 
+----------------
+              0
+(1 row)
+
+-- Cleanup
+SET pg_savior.bypass = on;
+DROP TABLE big_emp;
+DROP TABLE small_emp;
+DROP TABLE small_b;
+RESET pg_savior.bypass;

--- a/pg_savior.c
+++ b/pg_savior.c
@@ -142,6 +142,29 @@ column_has_default(ColumnDef *col)
 	return false;
 }
 
+/*
+ * Decide whether this AlterTableCmd is the kind that triggers a rewrite of a
+ * large table. Returns the human-readable name of the dangerous operation, or
+ * NULL if the cmd is harmless.
+ */
+static const char *
+pg_savior_alter_table_op(AlterTableCmd *cmd)
+{
+	switch (cmd->subtype)
+	{
+		case AT_AddColumn:
+			if (column_has_default((ColumnDef *) cmd->def))
+				return "ADD COLUMN with DEFAULT";
+			return NULL;
+
+		case AT_AlterColumnType:
+			return "ALTER COLUMN TYPE";
+
+		default:
+			return NULL;
+	}
+}
+
 static void
 pg_savior_check_alter_table(AlterTableStmt *stmt)
 {
@@ -151,13 +174,9 @@ pg_savior_check_alter_table(AlterTableStmt *stmt)
 	foreach (lc, stmt->cmds)
 	{
 		AlterTableCmd *cmd = (AlterTableCmd *) lfirst(lc);
-		ColumnDef  *col;
+		const char *op = pg_savior_alter_table_op(cmd);
 
-		if (cmd->subtype != AT_AddColumn)
-			continue;
-
-		col = (ColumnDef *) cmd->def;
-		if (!column_has_default(col))
+		if (op == NULL)
 			continue;
 
 		/* Lazy lookup: only inspect the relation once, only if needed */
@@ -172,12 +191,36 @@ pg_savior_check_alter_table(AlterTableStmt *stmt)
 
 		ereport(ERROR,
 				(errcode(ERRCODE_RAISE_EXCEPTION),
-				 errmsg("pg_savior: ALTER TABLE ADD COLUMN with DEFAULT on a large table (%.0f rows) is blocked",
-						reltuples),
-				 errhint("Adding a column with a volatile default rewrites the whole table. "
-						 "Add the column without a default first, then backfill in batches; "
-						 "raise pg_savior.large_table_threshold_rows; or set pg_savior.bypass = on. "
-						 "Run ANALYZE if the row estimate looks wrong.")));
+				 errmsg("pg_savior: ALTER TABLE %s on a large table (%.0f rows) is blocked",
+						op, reltuples),
+				 errhint("This operation rewrites the whole table. "
+						 "Plan a batched migration; raise pg_savior.large_table_threshold_rows; "
+						 "or set pg_savior.bypass = on. Run ANALYZE if the row estimate looks wrong.")));
+	}
+}
+
+static void
+pg_savior_check_truncate(TruncateStmt *stmt)
+{
+	ListCell *lc;
+
+	foreach (lc, stmt->relations)
+	{
+		RangeVar   *rv = (RangeVar *) lfirst(lc);
+		double		reltuples = pg_savior_relation_tuples(rv);
+
+		if (reltuples < 0)
+			continue;
+
+		if (reltuples <= pg_savior_large_table_threshold_rows)
+			continue;
+
+		ereport(ERROR,
+				(errcode(ERRCODE_RAISE_EXCEPTION),
+				 errmsg("pg_savior: TRUNCATE on a large table \"%s\" (%.0f rows) is blocked",
+						rv->relname, reltuples),
+				 errhint("Verify the target, raise pg_savior.large_table_threshold_rows, "
+						 "or set pg_savior.bypass = on. Run ANALYZE if the row estimate looks wrong.")));
 	}
 }
 
@@ -243,6 +286,8 @@ pg_savior_ProcessUtility(PlannedStmt *pstmt,
 			pg_savior_check_drop((DropStmt *) parsetree);
 		else if (IsA(parsetree, DropdbStmt))
 			pg_savior_check_drop_database((DropdbStmt *) parsetree);
+		else if (IsA(parsetree, TruncateStmt))
+			pg_savior_check_truncate((TruncateStmt *) parsetree);
 	}
 
 	if (prev_ProcessUtility_hook)

--- a/sql/unsafe_alter_column_type.sql
+++ b/sql/unsafe_alter_column_type.sql
@@ -1,0 +1,38 @@
+LOAD 'pg_savior';
+CREATE EXTENSION IF NOT EXISTS pg_savior;
+
+SET pg_savior.large_table_threshold_rows = 10;
+
+-- Small table: ALTER COLUMN TYPE allowed
+CREATE TABLE small_emp (id int);
+INSERT INTO small_emp SELECT generate_series(1, 5);
+ANALYZE small_emp;
+ALTER TABLE small_emp ALTER COLUMN id TYPE bigint;
+DROP TABLE small_emp;
+
+-- Large table: ALTER COLUMN TYPE blocked
+CREATE TABLE big_emp (id int, name text);
+INSERT INTO big_emp SELECT generate_series(1, 100), 'x';
+ANALYZE big_emp;
+ALTER TABLE big_emp ALTER COLUMN id TYPE bigint;
+
+-- Multi-cmd: blocked if any cmd is a type change
+ALTER TABLE big_emp ADD COLUMN extra int, ALTER COLUMN name TYPE varchar(50);
+
+-- Multi-cmd without type change or default: allowed
+ALTER TABLE big_emp ADD COLUMN y1 int, ADD COLUMN y2 int;
+
+-- Bypass overrides
+SET pg_savior.bypass = on;
+ALTER TABLE big_emp ALTER COLUMN id TYPE bigint;
+RESET pg_savior.bypass;
+
+-- Disabled also allowed
+SET pg_savior.enabled = off;
+ALTER TABLE big_emp ALTER COLUMN name TYPE varchar(100);
+SET pg_savior.enabled = on;
+
+-- Cleanup
+SET pg_savior.bypass = on;
+DROP TABLE big_emp;
+RESET pg_savior.bypass;

--- a/sql/unsafe_truncate.sql
+++ b/sql/unsafe_truncate.sql
@@ -1,0 +1,56 @@
+LOAD 'pg_savior';
+CREATE EXTENSION IF NOT EXISTS pg_savior;
+
+SET pg_savior.large_table_threshold_rows = 10;
+
+-- Small table: TRUNCATE allowed
+CREATE TABLE small_emp (id int);
+INSERT INTO small_emp SELECT generate_series(1, 5);
+ANALYZE small_emp;
+TRUNCATE small_emp;
+SELECT count(*) AS rowcount FROM small_emp;
+
+-- Large table: TRUNCATE blocked
+CREATE TABLE big_emp (id int);
+INSERT INTO big_emp SELECT generate_series(1, 100);
+ANALYZE big_emp;
+TRUNCATE big_emp;
+SELECT count(*) AS rowcount FROM big_emp;
+
+-- Multi-target: blocked if any large
+INSERT INTO small_emp SELECT generate_series(1, 5);
+ANALYZE small_emp;
+TRUNCATE small_emp, big_emp;
+-- Both still populated
+SELECT count(*) AS small_rowcount FROM small_emp;
+SELECT count(*) AS big_rowcount FROM big_emp;
+
+-- Multi-target where all are small: succeeds
+CREATE TABLE small_b (id int);
+INSERT INTO small_b VALUES (1);
+ANALYZE small_b;
+TRUNCATE small_emp, small_b;
+
+-- TRUNCATE ... CASCADE: same logic (CASCADE doesn't affect our check)
+TRUNCATE big_emp CASCADE;
+
+-- Bypass overrides
+SET pg_savior.bypass = on;
+TRUNCATE big_emp;
+RESET pg_savior.bypass;
+SELECT count(*) AS after_bypass FROM big_emp;
+
+-- Disabled: also allowed
+INSERT INTO big_emp SELECT generate_series(1, 100);
+ANALYZE big_emp;
+SET pg_savior.enabled = off;
+TRUNCATE big_emp;
+SET pg_savior.enabled = on;
+SELECT count(*) AS after_disabled FROM big_emp;
+
+-- Cleanup
+SET pg_savior.bypass = on;
+DROP TABLE big_emp;
+DROP TABLE small_emp;
+DROP TABLE small_b;
+RESET pg_savior.bypass;


### PR DESCRIPTION
## Summary
Two more checks on the existing `ProcessUtility_hook`:

1. **`TRUNCATE`** → `ERROR` when any target table is over `pg_savior.large_table_threshold_rows`. Multi-table truncates blocked if *any* target is large.
2. **`ALTER TABLE ALTER COLUMN TYPE`** → `ERROR` when target table is over the threshold. Type changes rewrite the table and take `ACCESS EXCLUSIVE` for the duration.

Both reuse `pg_savior.large_table_threshold_rows`. No new GUCs.

## Refactor
The `ALTER TABLE` check was previously hardcoded to `AT_AddColumn`-with-default. Refactored into a small dispatcher (`pg_savior_alter_table_op`) that returns the human-readable op name (or NULL for harmless cmds). Now handles `AT_AddColumn` with default *and* `AT_AlterColumnType`. Easy to extend further.

The error hint became generic enough to apply to both ("This operation rewrites the whole table. Plan a batched migration..."). Updated the existing `unsafe_add_column` expected output to match.

## Test plan
- [x] New `unsafe_truncate` regression test: small allowed, large blocked, multi-target with one large blocks, multi-target all small succeeds, CASCADE same logic, bypass, disabled
- [x] New `unsafe_alter_column_type` regression test: small allowed, large blocked, multi-cmd containing type change blocked, multi-cmd without type change allowed, bypass, disabled
- [x] Existing `unsafe_add_column` updated for new generic hint, still passes
- [x] All 12 tests pass on PG14, PG16, PG17
- [x] Eyeballed every captured `expected/*.out` for actual `ERROR:` strings before merging

🤖 Generated with [Claude Code](https://claude.com/claude-code)