### PR TITLE
Remove empty rules/ stubs from prior incarnation

### DIFF
--- a/rules/RD001.md
+++ b/rules/RD001.md
@@ -1,6 +1,0 @@
-| Rule  | Name           | Example         |
-| ----- | -------------- | --------------- |
-| D0001 | Vanilla Delete | Delete from emp |
-
-### Rule Description
-

--- a/rules/RD002.md
+++ b/rules/RD002.md
@@ -1,5 +1,0 @@
-| Rule  | Name                 | Example         |
-| ----- | -------------------- | --------------- |
-| D0001 | Delete with subquery | Delete from emp |
-
-### Rule Description


### PR DESCRIPTION
## Summary
The `rules/RD00*.md` files were placeholder docs the previous incarnation never filled in:

- [rules/RD001.md](rules/RD001.md) — 6 lines: a markdown table header + an empty `### Rule Description` section
- [rules/RD002.md](rules/RD002.md) — 4 lines: same shape, also empty
- [rules/RD003.md](rules/RD003.md) — 0 lines

They were tied to the `tests/RD00*.yml` ids that were removed in #12. The README documents every guard and what it blocks; the empty stubs only confused anyone browsing the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)